### PR TITLE
Namespace update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Docker Automated build](https://img.shields.io/docker/automated/gnode/meta.svg)](https://hub.docker.com/repository/docker/gnode/meta/)
+
 # The G-Node odml-query service
 
 odml-query is a SPARQL server based on [Apache Fuseki](

--- a/fuseki/webapp/js/app/qonsole-config.js
+++ b/fuseki/webapp/js/app/qonsole-config.js
@@ -8,7 +8,7 @@ define( [], function() {
       "rdfs":     "http://www.w3.org/2000/01/rdf-schema#",
       "owl":      "http://www.w3.org/2002/07/owl#",
       "xsd":      "http://www.w3.org/2001/XMLSchema#",
-      "odml":     "https://g-node.org/projects/odml-rdf#"
+      "odml":     "https://g-node.org/odml-rdf#"
     },
     queries: [
       { "name": "Generic query",

--- a/fuseki/webapp/js/app/qonsole-config.js
+++ b/fuseki/webapp/js/app/qonsole-config.js
@@ -11,6 +11,36 @@ define( [], function() {
       "odml":     "https://g-node.org/odml-rdf#"
     },
     queries: [
+      { "name": "Keyword query",
+        "query": "SELECT ?file ?keyword ?id_type_value ?doi_link" +
+                 "WHERE {" +
+                    "?doc rdf:type odml:Document ." +
+                    "?doc odml:hasFileName ?file ." +
+                    "?doc odml:hasSection ?s ." +
+                    "?s odml:hasSection ?ids ." +
+                    "?ids odml:hasProperty ?idp ." +
+                    "?ids odml:hasName ?secidname ." +
+                    "?idp odml:hasName \"identifier\" ." +
+                    "?idp odml:hasValue ?doival ." +
+                    "?ids odml:hasProperty ?pt ." +
+                    "?pt odml:hasName \"identifierType\" ." +
+                    "?pt odml:hasValue ?idtype ." +
+                    "?idtype rdfs:member ?id_type_value ." +
+                    "?doival rdfs:member ?doi_val ." +
+                    "?s odml:hasSection ?subcont ." +
+                    "?s odml:hasName ?sec_name ." +
+                    "?subcont odml:hasSection ?subj ." +
+                    "?subj odml:hasProperty ?p ." +
+                    "?p odml:hasName ?prop_name ." +
+                    "?p odml:hasValue ?v ." +
+                    "{?v rdfs:member \"Neuroscience\"} UNION {?v rdfs:member \"Electrophysiology\"} ." +
+                    "?v rdfs:member ?keyword ." +
+                    "BIND(CONCAT(\"https://doi.org/\", ?doi_val) AS ?doi_link)" +
+                 "}" +
+                 "ORDER BY ?file" +
+                 "LIMIT 50",
+        "prefixes": ["rdf", "rdfs", "odml"]
+      },
       { "name": "Generic query",
         "query": "SELECT ?subject ?predicate ?object\nWHERE {\n" +
                  "  ?subject ?predicate ?object\n}\n" +


### PR DESCRIPTION
This PR
- updates the custom odml RDF namespace to `https://g-node.org/odml-rdf#`. Closes #1.
- Adds an additional, more specific example query.
- Links to the corresponding docker container on dockerhub.
