### PR TITLE
log4j security issue hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,12 @@ VOLUME $FUSEKI_BASE
 ADD docker_startup.sh /fuseki
 RUN chmod +x ./docker_startup.sh
 
+# Mitigation of log4j vulnerability; required until the built in
+# log4j version in fuseki-server.jar has been updated to >= 2.15.0
+# Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+# Check https://logging.apache.org/log4j/2.x/security.html for details
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+
 #ENTRYPOINT sh fuseki-server --port=4044
 ENTRYPOINT ["./docker_startup.sh"]
 

--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env sh
 
-# Mitigation of log4j vulnerability; required until the built in
-# log4j version in fuseki-server.jar has been updated to >= 2.15.0
-# Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
-# Check https://logging.apache.org/log4j/2.x/security.html for details
-LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
 # Cleanup leftover database lock file if a server crash has happened,
 # otherwise the service can encounter restart issues.
 find /content/system/ -type f -name "tdb.lock" -delete

--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
 
+# Mitigation of log4j vulnerability; required until the built in
+# log4j version in fuseki-server.jar has been updated to >= 2.15.0
+# Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+# Check https://logging.apache.org/log4j/2.x/security.html for details
+LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+
 # Cleanup leftover database lock file if a server crash has happened,
 # otherwise the service can encounter restart issues.
 find /content/system/ -type f -name "tdb.lock" -delete

--- a/fuseki/fuseki-server
+++ b/fuseki/fuseki-server
@@ -104,7 +104,11 @@ fi
 
 JVM_ARGS=${JVM_ARGS:--Xmx4G}
 
-exec $JAVA $JVM_ARGS -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+exec $JAVA $JVM_ARGS -Dlog4j2.formatMsgNoLookups=true -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
 
 ## Adding custom code to the Fuseki server:
 ##

--- a/fuseki/log4j2.properties
+++ b/fuseki/log4j2.properties
@@ -10,8 +10,12 @@ appender.console.type = Console
 appender.console.name = OUT
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
-#appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m{nolookups}%n
+#appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m{nolookups}%n
 
 rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT
@@ -60,7 +64,11 @@ logger.shiro-realm.level = ERROR
 appender.plain.type = Console
 appender.plain.name = PLAIN
 appender.plain.layout.type = PatternLayout
-appender.plain.layout.pattern = %m%n
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+appender.plain.layout.pattern = %m{nolookups}%n
 
 logger.fuseki-request.name                   = org.apache.jena.fuseki.Request
 logger.fuseki-request.additivity             = false

--- a/fuseki/webapp/log4j2.properties
+++ b/fuseki/webapp/log4j2.properties
@@ -8,7 +8,11 @@ appender.console.type = Console
 appender.console.name = OUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-10c{1} %-5p %m%n
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-10c{1} %-5p %m{nolookups}%n
 
 rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT
@@ -53,7 +57,11 @@ logger.shiro-realm.level = ERROR
 appender.plain.type = Console
 appender.plain.name = PLAIN
 appender.plain.layout.type = PatternLayout
-appender.plain.layout.pattern = %m%n
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+appender.plain.layout.pattern = %m{nolookups}%n
 
 logger.fuseki-request.name                   = org.apache.jena.fuseki.Request
 logger.fuseki-request.additivity             = false


### PR DESCRIPTION
Mitigation of a log4j vulnerability; the introduced changes are required until the built in log4j version in fuseki-server.jar has been updated to >= 2.15.0.

Closes #11.