### PR TITLE
Log4j update

### DIFF
--- a/FUSEKI_NOTES
+++ b/FUSEKI_NOTES
@@ -1,8 +1,8 @@
 The server in its current build uses the following software versions:
 
-Jena:       VERSION: 4.1.0
-Jena:       BUILD_DATE: 2021-05-31T20:32:25+0000
-TDB:        VERSION: 4.1.0
-TDB:        BUILD_DATE: 2021-05-31T20:32:25+0000
-Fuseki:     VERSION: 4.1.0
-Fuseki:     BUILD_DATE: 2021-05-31T20:32:25+0000
+Jena:       VERSION: 4.3.2
+Jena:       BUILD_DATE: 2021-12-17T18:56:02Z
+TDB:        VERSION: 4.3.2
+TDB:        BUILD_DATE: 2021-12-17T18:56:02Z
+Fuseki:     VERSION: 4.3.2
+Fuseki:     BUILD_DATE: 2021-12-17T18:56:02Z

--- a/fuseki/LICENSE
+++ b/fuseki/LICENSE
@@ -230,6 +230,16 @@ http://www.slf4j.org/license.html
 
 - - - - - - - - - - - - - - - - - - - - - - - 
 
+Jakarta JSON Processing (JSON-P)
+https://eclipse-ee4j.github.io/jsonp/
+
+is licensed under the Eclipse Public License 2.0.
+http://www.eclipse.org/legal/epl-2.0
+
+org.glassfish:jakarta.json
+is licensed under the Eclipse Public License 2.0.
+http://www.eclipse.org/legal/epl-2.0
+
 ==============================================================
  Jetty Web Container
  Copyright 1995-2012 Mort Bay Consulting Pty Ltd.
@@ -332,16 +342,7 @@ See http://yasr.yasgui.org/license.txt
 
 - - - - - - - - - - - - - - - - - - - - - - - 
 
-From Apache HttpComponents Client
-
-This project contains annotations derived from JCIP-ANNOTATIONS
-Copyright (c) 2005 Brian Goetz and Tim Peierls.
-See http://www.jcip.net and the Creative Commons Attribution License 
-(http://creativecommons.org/licenses/by/2.5)
-
-- - - - - - - - - - - - - - - - - - - - - - - 
-
-From Apache Lucene
+From Apache Lucene:
 
 Some code in core/src/java/org/apache/lucene/util/UnicodeUtil.java was
 derived from unicode conversion examples available at
@@ -614,4 +615,4 @@ WHETHER IN  CONTRACT, STRICT LIABILITY, OR  TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
+---

--- a/fuseki/NOTICE
+++ b/fuseki/NOTICE
@@ -37,13 +37,6 @@ modified April 2001  by Iris Van den Broeke, Daniel Deville.
 
 - - - - - - - - - - - - - - - - - - - - - - -
 
-From Apache HttpComponents Client:
-
-This project contains annotations derived from JCIP-ANNOTATIONS
-Copyright (c) 2005 Brian Goetz and Tim Peierls. See http://www.jcip.net
-
-- - - - - - - - - - - - - - - - - - - - - - -
-
   Apache Xerces Java
    Copyright 1999-2013 The Apache Software Foundation
 
@@ -56,6 +49,13 @@ Copyright (c) 2005 Brian Goetz and Tim Peierls. See http://www.jcip.net
      - voluntary contributions made by Paul Eng on behalf of the 
        Apache Software Foundation that were originally developed at iClick, Inc.,
        software copyright (c) 1999.
+
+- - - - - - - - - - - - - - - - - - - - - - -
+
+This product bundles Google Protocol Buffers java runtime:
+
+Copyright 2008 Google Inc.  All rights reserved.
+https://github.com/protocolbuffers/protobuf/blob/master/LICENSE
 
 - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/fuseki/bin/soh
+++ b/fuseki/bin/soh
@@ -64,7 +64,7 @@ $mtSparqlQuery      = "application/sparql-query" ;
 $fileMediaTypes = {}
 $fileMediaTypes['ttl']   = $mtTurtle
 $fileMediaTypes['n3']    = 'text/n3; charset=utf-8'
-$fileMediaTypes['nt']    = $mtText
+$fileMediaTypes['nt']    = $mtNTriples
 $fileMediaTypes['rdf']   = $mtRDF
 $fileMediaTypes['owl']   = $mtRDF
 $fileMediaTypes['nq']    = $mtNQuads
@@ -73,10 +73,9 @@ $fileMediaTypes['json-ld']  = $mtJSONLD
 $fileMediaTypes['jsonld']  = $mtJSONLD
 
 # Global charset : no entry means "don't set"
-$charsetUTF8      = 'utf-8'
+$charsetUTF8          = 'utf-8'
 $charset = {}
 $charset[$mtTurtle]   = 'utf-8'
-$charset[$mtText]     = 'ascii'
 $charset[$mtTriG]     = 'utf-8'
 $charset[$mtNQuads]   = 'utf-8'
 

--- a/fuseki/fuseki
+++ b/fuseki/fuseki
@@ -281,7 +281,7 @@ fi
 # Some JVM settings
 if [ -z "$JAVA_OPTIONS" ]
 then
-  JAVA_OPTIONS="-Xmx1200M"
+  JAVA_OPTIONS="-Xmx1500M"
 fi
 
 # Default Fuseki Arguments

--- a/fuseki/fuseki-server
+++ b/fuseki/fuseki-server
@@ -112,7 +112,11 @@ then
     LOGGING="-Dlog4j.configurationFile=$DFT_LOG_CONF"
 fi
 
-exec $JAVA $JVM_ARGS $LOGGING -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+exec $JAVA $JVM_ARGS -Dlog4j2.formatMsgNoLookups=true $LOGGING -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
 
 ## Adding custom code to the Fuseki server:
 ##

--- a/fuseki/fuseki-server
+++ b/fuseki/fuseki-server
@@ -104,11 +104,15 @@ fi
 
 JVM_ARGS=${JVM_ARGS:--Xmx4G}
 
-# This applies a log4j security vulnerability mitigation and should only
-# be changed back to default when the used log4j version has been upgraded
-# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
-# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
-exec $JAVA $JVM_ARGS -Dlog4j2.formatMsgNoLookups=true -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
+## Logging
+# Setting log4j2 with some other file.
+if [ -z "$LOGGING" ]
+then
+    DFT_LOG_CONF="$FUSEKI_HOME/log4j2.properties"
+    LOGGING="-Dlog4j.configurationFile=$DFT_LOG_CONF"
+fi
+
+exec $JAVA $JVM_ARGS $LOGGING -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
 
 ## Adding custom code to the Fuseki server:
 ##

--- a/fuseki/log4j2.properties
+++ b/fuseki/log4j2.properties
@@ -10,12 +10,8 @@ appender.console.type = Console
 appender.console.name = OUT
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
-# This applies a log4j security vulnerability mitigation and should only
-# be changed back to default when the used log4j version has been upgraded
-# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
-# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
-appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m{nolookups}%n
-#appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m{nolookups}%n
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
+#appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
 
 rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT
@@ -64,11 +60,7 @@ logger.shiro-realm.level = ERROR
 appender.plain.type = Console
 appender.plain.name = PLAIN
 appender.plain.layout.type = PatternLayout
-# This applies a log4j security vulnerability mitigation and should only
-# be changed back to default when the used log4j version has been upgraded
-# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
-# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
-appender.plain.layout.pattern = %m{nolookups}%n
+appender.plain.layout.pattern = %m%n
 
 logger.fuseki-request.name                   = org.apache.jena.fuseki.Request
 logger.fuseki-request.additivity             = false

--- a/fuseki/log4j2.properties
+++ b/fuseki/log4j2.properties
@@ -10,8 +10,12 @@ appender.console.type = Console
 appender.console.name = OUT
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
-#appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m{nolookups}%n
+#appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m{nolookups}%n
 
 rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT
@@ -60,7 +64,11 @@ logger.shiro-realm.level = ERROR
 appender.plain.type = Console
 appender.plain.name = PLAIN
 appender.plain.layout.type = PatternLayout
-appender.plain.layout.pattern = %m%n
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+appender.plain.layout.pattern = %m{nolookups}%n
 
 logger.fuseki-request.name                   = org.apache.jena.fuseki.Request
 logger.fuseki-request.additivity             = false

--- a/fuseki/webapp/WEB-INF/web.xml
+++ b/fuseki/webapp/WEB-INF/web.xml
@@ -114,48 +114,6 @@
     <dispatcher>ERROR</dispatcher>
   </filter-mapping>
 
-  <!-- Validators -->
-
-  <servlet>
-    <servlet-name>QueryValidator</servlet-name>
-    <servlet-class>org.apache.jena.fuseki.validation.QueryValidator</servlet-class>
-  </servlet>
-
-  <servlet>
-    <servlet-name>UpdateValidator</servlet-name>
-    <servlet-class>org.apache.jena.fuseki.validation.UpdateValidator</servlet-class>
-  </servlet>
-
-  <servlet>
-    <servlet-name>DataValidator</servlet-name>
-    <servlet-class>org.apache.jena.fuseki.validation.DataValidator</servlet-class>
-  </servlet>
-
-  <servlet>
-    <servlet-name>IRIValidator</servlet-name>
-    <servlet-class>org.apache.jena.fuseki.validation.IRIValidator</servlet-class>
-  </servlet>
-
-  <servlet-mapping>
-    <servlet-name>QueryValidator</servlet-name>
-    <url-pattern>/validate/query</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>UpdateValidator</servlet-name>
-    <url-pattern>/validate/update</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>IRIValidator</servlet-name>
-    <url-pattern>/validate/iri</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>DataValidator</servlet-name>
-    <url-pattern>/validate/data</url-pattern>
-  </servlet-mapping>
-
   <!-- Server controls-->
   
   <servlet>

--- a/fuseki/webapp/log4j2.properties
+++ b/fuseki/webapp/log4j2.properties
@@ -8,7 +8,11 @@ appender.console.type = Console
 appender.console.name = OUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-10c{1} %-5p %m%n
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-10c{1} %-5p %m{nolookups}%n
 
 rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT
@@ -53,7 +57,11 @@ logger.shiro-realm.level = ERROR
 appender.plain.type = Console
 appender.plain.name = PLAIN
 appender.plain.layout.type = PatternLayout
-appender.plain.layout.pattern = %m%n
+# This applies a log4j security vulnerability mitigation and should only
+# be changed back to default when the used log4j version has been upgraded
+# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
+# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
+appender.plain.layout.pattern = %m{nolookups}%n
 
 logger.fuseki-request.name                   = org.apache.jena.fuseki.Request
 logger.fuseki-request.additivity             = false

--- a/fuseki/webapp/log4j2.properties
+++ b/fuseki/webapp/log4j2.properties
@@ -8,11 +8,7 @@ appender.console.type = Console
 appender.console.name = OUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-# This applies a log4j security vulnerability mitigation and should only
-# be changed back to default when the used log4j version has been upgraded
-# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
-# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
-appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-10c{1} %-5p %m{nolookups}%n
+appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-10c{1} %-5p %m%n
 
 rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT
@@ -57,11 +53,7 @@ logger.shiro-realm.level = ERROR
 appender.plain.type = Console
 appender.plain.name = PLAIN
 appender.plain.layout.type = PatternLayout
-# This applies a log4j security vulnerability mitigation and should only
-# be changed back to default when the used log4j version has been upgraded
-# to >= 2.15.0; check https://logging.apache.org/log4j/2.x/security.html
-# for details; Check fuseki-server.jar:METAINF/DEPENDENCIES for the used version.
-appender.plain.layout.pattern = %m{nolookups}%n
+appender.plain.layout.pattern = %m%n
 
 logger.fuseki-request.name                   = org.apache.jena.fuseki.Request
 logger.fuseki-request.additivity             = false


### PR DESCRIPTION
This PR updates the fuseki server version to 4.3.2. This fixes the most relevant log4j security issues.